### PR TITLE
Fix missing timestamp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ShellyInflux"
-version = "0.1.0"
+version = "0.1.1"
 description = "An application to periodically read statistics from Shelly devices and pipe them to InfluxDB."
 authors = [{name = "@GiantMolecularCloud"}]
 license = {file = "LICENSE"}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1"
+__version__ = "0.1.1"
 __author__ = "@GiantMolecularCloud"

--- a/src/shelly.py
+++ b/src/shelly.py
@@ -77,7 +77,12 @@ class Shelly:
             measures["request_elapsed"] = request.elapsed.total_seconds()
             if request.status_code == 200:
                 json = request.json()
-                time = datetime.utcfromtimestamp(json["unixtime"])
+                if "unixtime" in json.keys():  # Shelly 3PM
+                    time = datetime.utcfromtimestamp(json["unixtime"])
+                elif "meters0_timestamp" in json.keys():  # Shelly Plug S
+                    time = datetime.utcfromtimestamp(json["meters0_timestamp"])
+                else:
+                    time = request_time
                 measures = self._get_measures_from_json(measures, json)
             else:
                 time = request_time


### PR DESCRIPTION
Some devices do not supply a "timestamp" field which caused a crash since no time could be inferred.
This fix tries to get a timestamp from other fields: in some cases, the meter has a timestamp (e.g. Plug S). If neither "timestamp", nor "meter: timestamp" are present, the time at which the request was sent is used.